### PR TITLE
Add related work: "RBs for Maven Central Repository"

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,12 @@ endings.
 
 - [Reproducible Builds]: A project dedicated to promoting and making builds
   reproducible.
+- [Reproducible Builds for Maven Central Repository]: A project dedicated to
+  rebuild instructions for artifacts published to (Maven) Central Repository.
 - [ActionsRemaker] ([demo][actionsremaker demo]): A tangentially related project
   that aims to reproduce GitHub Actions jobs (rather than Actions themselves).
 
 [reproducible builds]: https://reproducible-builds.org/
+[reproducible builds for maven central repository]: https://github.com/jvm-repo-rebuild/reproducible-central
 [actionsremaker demo]: https://www.youtube.com/watch?v=flblSqoxeAk
 [actionsremaker]: http://cdn.zhuhaonan.com/files/icse-23-actionsremaker.pdf


### PR DESCRIPTION
Relates to #5

## Summary

Add a new related work item for the ["https://github.com/jvm-repo-rebuild/reproducible-central?" project](https://github.com/jvm-repo-rebuild/reproducible-central). It tries to do something similar to this project but for Java project, targeting exact versions instead of major versions/moving targets.