### PR TITLE
Add monitor for dorny/paths-filter at v3

### DIFF
--- a/.github/workflows/dorny-paths-filter-v3.yml
+++ b/.github/workflows/dorny-paths-filter-v3.yml
@@ -1,0 +1,29 @@
+name: dorny/paths-filter@v3
+on:
+  pull_request:
+    paths:
+      - .github/workflows/reusable-test.yml
+      - .github/workflows/dorny-paths-filter-v3.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/reusable-test.yml
+      - .github/workflows/dorny-paths-filter-v3.yml
+  schedule:
+    - cron: "23 1 * * *"
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  v3:
+    name: v3
+    uses: ericcornelissen/reproducing-actions/.github/workflows/reusable-test.yml@main
+    with:
+      files:        dist/index.js
+      build-cmd:    npm run build
+      install-cmd:  npm clean-install
+      node-version: 20.x
+      repository:   dorny/paths-filter
+      version-ref:  v3

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ with more information about the project and statuses.
 | [docker/login-action@v3] | v3 | [![][docker/login-action-v3-badge]][docker/login-action-v3-url] |
 | [docker/build-push-action@v5] | v5 | [![][docker/build-push-action-v5-badge]][docker/build-push-action-v5-url] |
 | [github/codeql-action@v3] | v3 | [![][github/codeql-action-v3-badge]][github/codeql-action-v3-url] |
+| [dorny/paths-filter@v3] | v3 | [![][dorny/paths-filter-v3-badge]][dorny/paths-filter-v3-url] |
 <!-- INSERT ROW -->
+[dorny/paths-filter@v3]: https://github.com/dorny/paths-filter/tree/v3
+[dorny/paths-filter-v3-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/dorny-paths-filter-v3.yml/badge.svg?event=schedule
+[dorny/paths-filter-v3-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/dorny-paths-filter-v3.yml
 [github/codeql-action@v3]: https://github.com/github/codeql-action/tree/v3
 [github/codeql-action-v3-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/github-codeql-action-v3.yml/badge.svg?event=schedule
 [github/codeql-action-v3-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/github-codeql-action-v3.yml


### PR DESCRIPTION
## Summary

Create a new monitor for the [dorny/paths-filter](https://github.com/dorny/paths-filter) action.

The monitor is for the latest major version. The `files:` are based on the files that exist in the project's `dist/` directory. The build-cmd is based on the list of commands the project declares in `package.json`. The install-cmd is chosen based on the fact that the project has a `package-lock.json` file. The node-version is based on the `"engines"` value in the project manifest.

All this is based on the state of the repository at commit: [de90cc6fb38fc0963ad72b210f1f284cd68cea36](https://github.com/dorny/paths-filter/tree/de90cc6fb38fc0963ad72b210f1f284cd68cea36)