### PR TITLE
Upgrade the Ubuntu-based runner used in CI to 24.04

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -44,7 +44,7 @@ permissions: read-all
 jobs:
   build:
     name: Reproducible build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CHECKSUMS_FILE: reproducing-actions-checksums.txt
       BACKUP_DIR: /tmp/reproducing-actions


### PR DESCRIPTION
## Summary

Upgrade the Ubuntu-based runner used in CI from 22.04 to 24.04. **NOTE:** As of writing this runner is still in beta, so this should not be merged.