### PR TITLE
Add monitor for `actions/attest-build-provenance` at v1

### DIFF
--- a/.github/workflows/actions-attest-build-provenance-v1.yml
+++ b/.github/workflows/actions-attest-build-provenance-v1.yml
@@ -1,0 +1,29 @@
+name: actions/attest-build-provenance@v1
+on:
+  pull_request:
+    paths:
+      - .github/workflows/reusable-test.yml
+      - .github/workflows/actions-attest-build-provenance-v1.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/reusable-test.yml
+      - .github/workflows/actions-attest-build-provenance-v1.yml
+  schedule:
+    - cron: "24 1 * * *"
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  v1:
+    name: v1
+    uses: ericcornelissen/reproducing-actions/.github/workflows/reusable-test.yml@main
+    with:
+      files:             dist/index.js
+      build-cmd:         npm run package
+      install-cmd:       npm clean-install
+      node-version-file: .node-version
+      repository:        actions/attest-build-provenance
+      version-ref:       v1

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ with more information about the project and statuses.
 | [docker/build-push-action@v5] | v5 | [![][docker/build-push-action-v5-badge]][docker/build-push-action-v5-url] |
 | [github/codeql-action@v3] | v3 | [![][github/codeql-action-v3-badge]][github/codeql-action-v3-url] |
 | [dorny/paths-filter@v3] | v3 | [![][dorny/paths-filter-v3-badge]][dorny/paths-filter-v3-url] |
+| [actions/attest-build-provenance@v1] | v1 | [![][actions/attest-build-provenance-v1-badge]][actions/attest-build-provenance-v1-url] |
 <!-- INSERT ROW -->
+[actions/attest-build-provenance@v1]: https://github.com/actions/attest-build-provenance/tree/v1
+[actions/attest-build-provenance-v1-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/actions-attest-build-provenance-v1.yml/badge.svg?event=schedule
+[actions/attest-build-provenance-v1-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/actions-attest-build-provenance-v1.yml
 [dorny/paths-filter@v3]: https://github.com/dorny/paths-filter/tree/v3
 [dorny/paths-filter-v3-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/dorny-paths-filter-v3.yml/badge.svg?event=schedule
 [dorny/paths-filter-v3-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/dorny-paths-filter-v3.yml


### PR DESCRIPTION
## Summary

Create a new monitor for the [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) action.

The monitor is for the latest major version. The `files:` are based on the files that exist in the project's `dist/` directory. The build-cmd is based on the list of commands the project declares in `package.json`. The install-cmd is chosen based on the fact that the project has a `package-lock.json` file. The node-version-file is based on the `node-version-file` value used in the project's own workflows.

All this is based on the state of the repository at commit: [8f1fc17a59ea731736cdf0e179a0dcf1f6270453](https://github.com/actions/attest-build-provenance/tree/8f1fc17a59ea731736cdf0e179a0dcf1f6270453)