### PR TITLE
Enable corepack to resolve yarn issues for `docker/build-push-action@v5`

### DIFF
--- a/.github/workflows/docker-build-push-action-v5.yml
+++ b/.github/workflows/docker-build-push-action-v5.yml
@@ -23,7 +23,9 @@ jobs:
     with:
       files:        dist/index.js
       build-cmd:    yarn build
-      install-cmd:  yarn install
+      install-cmd:  |
+        corepack enable
+        yarn install
       node-version: 20.x
       repository:   docker/build-push-action
       version-ref:  v5


### PR DESCRIPTION
Relates to #19