### PR TITLE
Add direct comparison of build files

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       CHECKSUMS_FILE: reproducing-actions-checksums.txt
+      BACKUP_DIR: /tmp/reproducing-actions
     steps:
       # Repository setup
       - name: Checkout repository
@@ -78,7 +79,11 @@ jobs:
             echo "Normalizing line endings in '$file'"
             sed -i 's/\r$//' "$file"
           done
-      - name: Compute original checksums
+      - name: Store original build files
+        run: |
+          mkdir --parents "$BACKUP_DIR"
+          cp --parents ${{ inputs.files }} "$BACKUP_DIR"
+      - name: Compute original checksums (legacy)
         run: |
           shasum --algorithm 512 ${{ inputs.files }} >$CHECKSUMS_FILE
 
@@ -95,7 +100,17 @@ jobs:
             echo "Normalizing line endings in '$file'"
             sed -i 's/\r$//' "$file"
           done
-      - name: Check checksums
+      - name: Check build files
+        env:
+          files: ${{ inputs.files }}
+        run: |
+          for file in $files; do
+            rebuild=$file
+            original=$BACKUP_DIR/$file
+            echo "Checking '$rebuild' against '$original'"
+            cmp "$rebuild" "$original"
+          done
+      - name: Check checksums (legacy)
         run: shasum --strict --check $CHECKSUMS_FILE
       - name: Build files diff
         if: ${{ failure() }}


### PR DESCRIPTION
Closes #25

## Summary

Update the reusable workflow to compare build files directly instead of comparing their checksum. This removes the unnecessary(?) chance of false negatives due to hash collisions. For comparison, the hash-based reproducibility check is kept for now - marked as "legacy" - mainly just to see if there's a difference in the short run in case there's an error in the implementation of the new approach. This legacy check may be removed in the future.