### PR TITLE
Drop the Dependabot `open-pull-requests-limit`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
-    open-pull-requests-limit: 1
     labels:
       - dependencies
     schedule:


### PR DESCRIPTION
Relates to #61