### PR TITLE
Fix SC2086 shellcheck warnings in reusable-test.yml

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -115,7 +115,7 @@ jobs:
 
           echo 'Checksums:'
           echo '----------'
-          cat $CHECKSUMS_FILE
+          cat "$CHECKSUMS_FILE"
 
       - name: Rebuild
         working-directory: ${{ inputs.working-directory }}
@@ -136,7 +136,7 @@ jobs:
             cmp "$rebuild" "$original"
           done <"$FILES_LIST_FILE"
       - name: Check checksums (legacy)
-        run: shasum --strict --check $CHECKSUMS_FILE
+        run: shasum --strict --check "$CHECKSUMS_FILE"
 
       - name: Build files diff
         if: ${{ failure() }}
@@ -152,5 +152,5 @@ jobs:
           before=$FILES_LIST_FILE
           after=$FILES_LIST_FILE.2
 
-          find . \( -path ./.git \) -prune -o -type f -print >$after
+          find . \( -path ./.git \) -prune -o -type f -print >"$after"
           diff "$after" "$before"


### PR DESCRIPTION
## Summary
- Fix three shellcheck SC2086 (`Double quote to prevent globbing and word splitting`) warnings in `reusable-test.yml`
- These were surfaced by the actionlint CI check

## Changes
- Line 118: `cat $CHECKSUMS_FILE` → `cat "$CHECKSUMS_FILE"`
- Line 139: `shasum --strict --check $CHECKSUMS_FILE` → `shasum --strict --check "$CHECKSUMS_FILE"`
- Line 155: `find ... >$after` → `find ... >"$after"`

## Testing
- The actionlint CI check should pass after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)