### PR TITLE
Bump asdf-vm/actions from 4.0.0 to 4.0.1

### DIFF
--- a/.github/workflows/0-ci.yml
+++ b/.github/workflows/0-ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install tooling
-        uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 # v4.0.0
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
       - name: ${{ matrix.what }}
         run: ${{ matrix.how }}
   gha-release:


### PR DESCRIPTION
Relates to #78

Re-opening because 4.0.1 uses an updated Node.js engine that we should make use of, see https://github.com/asdf-vm/actions/compare/v4.0.0...v4.0.1#diff-e137b8c43202fa4c61e555ac8b43bb8a7b75378e68e5298b711f2874571f0363R5