### PR TITLE
Add monitor for `google/osv-scanner-action` at v2.3.5

### DIFF
--- a/.github/workflows/0-ci.yml
+++ b/.github/workflows/0-ci.yml
@@ -24,6 +24,19 @@ jobs:
           - what: Formatting
             how: |
               shfmt --simplify --diff new.sh
+          - what: Schedules
+            how: |
+              duplicates=$( \
+                grep -Rho '^[[:space:]]*- cron: ".*"' .github/workflows/*.yml \
+                  | sed 's/.*cron: "\(.*\)"/\1/' \
+                  | sort \
+                  | uniq -d \
+              )
+              if [[ -n $duplicates ]]; then
+                echo 'The following cron values appear multiple times:'
+                echo "$duplicates"
+                exit 1
+              fi
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/0-ci.yml
+++ b/.github/workflows/0-ci.yml
@@ -20,10 +20,10 @@ jobs:
               actionlint
           - what: Shell scripts
             how: |
-              shellcheck new.sh
+              shellcheck new.sh remove.sh
           - what: Formatting
             how: |
-              shfmt --simplify --diff new.sh
+              shfmt --simplify --diff new.sh remove.sh
           - what: Schedules
             how: |
               duplicates=$( \

--- a/.github/workflows/extractions-setup-crate.yml
+++ b/.github/workflows/extractions-setup-crate.yml
@@ -20,12 +20,13 @@ jobs:
   test:
     uses: ./.github/workflows/reusable-node-test.yml
     with:
+      bun-version:  latest
       build-cmd:    npm run build
       install-cmd:  npm clean-install
-      node-version: 20
+      node-version: 24
       repository:   extractions/setup-crate
   version:
     if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: extractions/setup-crate@v1.4.0
+      - uses: extractions/setup-crate@v2.0.0

--- a/.github/workflows/google-osv-scanner-action.yml
+++ b/.github/workflows/google-osv-scanner-action.yml
@@ -1,0 +1,30 @@
+name: google/osv-scanner-action
+on:
+  pull_request:
+    paths:
+      - .github/workflows/reusable-docker-image-test.yml
+      - .github/workflows/google-osv-scanner-action.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/reusable-docker-image-test.yml
+      - .github/workflows/google-osv-scanner-action.yml
+  schedule:
+    - cron: "53 1 * * *"
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-docker-image-test.yml
+    with:
+      dockerfile: goreleaser-action.dockerfile
+      image: ghcr.io/google/osv-scanner-action:v2.3.5
+      repository: google/osv-scanner
+  version:
+    if: ${{ false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google/osv-scanner-action@v2.3.5

--- a/.github/workflows/google-osv-scanner-action.yml
+++ b/.github/workflows/google-osv-scanner-action.yml
@@ -23,6 +23,14 @@ jobs:
       dockerfile: goreleaser-action.dockerfile
       image: ghcr.io/google/osv-scanner-action:v2.3.5
       repository: google/osv-scanner
+      setup-cmd: >-
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+        go build -trimpath -ldflags="-s -w"
+        -o osv-scanner-action ./cmd/osv-scanner
+        &&
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+        go build -trimpath -ldflags="-s -w"
+        -o osv-reporter ./cmd/osv-reporter
   version:
     if: ${{ false }}
     runs-on: ubuntu-latest

--- a/.github/workflows/mikefarah-yq.yml
+++ b/.github/workflows/mikefarah-yq.yml
@@ -1,0 +1,30 @@
+name: mikefarah/yq
+on:
+  pull_request:
+    paths:
+      - .github/workflows/reusable-docker-image-test.yml
+      - .github/workflows/mikefarah-yq.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/reusable-docker-image-test.yml
+      - .github/workflows/mikefarah-yq.yml
+  schedule:
+    - cron: "49 1 * * *"
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-docker-image-test.yml
+    with:
+      dockerfile: Dockerfile
+      image: mikefarah/yq:4-githubaction
+      repository: mikefarah/yq
+  version:
+    if: ${{ false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mikefarah/yq@v4.52.5

--- a/.github/workflows/pnpm-action-setup.yml
+++ b/.github/workflows/pnpm-action-setup.yml
@@ -1,0 +1,33 @@
+name: pnpm/action-setup
+on:
+  pull_request:
+    paths:
+      - .github/workflows/reusable-node-test.yml
+      - .github/workflows/pnpm-action-setup.yml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/reusable-node-test.yml
+      - .github/workflows/pnpm-action-setup.yml
+  schedule:
+    - cron: "51 1 * * *"
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  test:
+    uses: ./.github/workflows/reusable-node-test.yml
+    with:
+      build-cmd:    pnpm run build
+      install-cmd:  |
+        corepack enable
+        corepack prepare pnpm@^9 --activate
+        corepack pnpm install
+      repository:   pnpm/action-setup
+  version:
+    if: ${{ false }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pnpm/action-setup@v5.0.0

--- a/.github/workflows/reusable-docker-image-test.yml
+++ b/.github/workflows/reusable-docker-image-test.yml
@@ -1,0 +1,78 @@
+name: Check
+on:
+  workflow_call:
+    inputs:
+      # Setup
+      dockerfile:
+        required: true
+        type: string
+      image:
+        required: true
+        type: string
+
+      # Target
+      repository:
+        required: true
+        type: string
+
+permissions: read-all
+
+jobs:
+  setup:
+    name: setup
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Determine version to reproduce
+        id: version
+        env:
+          REPO: ${{ inputs.repository }}
+        run: |
+          WORKFLOW=$(echo "${REPO//\//-}.yml" | tr '[:upper:]' '[:lower:]')
+          VERSION=$( \
+            cat ".github/workflows/$WORKFLOW" \
+              | grep -oE '^\s+- uses: [^@]+@v?[^"]*' \
+              | sed 's/.*@//' \
+          )
+          echo "$VERSION"
+          echo "version=$VERSION" >>"$GITHUB_OUTPUT"
+  build:
+    name: build ${{ needs.setup.outputs.version }}
+    runs-on: ubuntu-24.04
+    needs:
+      - setup
+    env:
+      DOCKERFILE: ${{ inputs.dockerfile }}
+      IMAGE: ${{ inputs.image }}
+    steps:
+      # Repository setup
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.setup.outputs.version }}
+          repository: ${{ inputs.repository }}
+
+      # Environment setup
+      - name: Install diffoci
+        env:
+          CHECKSUM: 01e6b50c1568c9d61c758ef6da81869f2c26c852698d73dca961b3617effe949
+          DIFFOCI_VERSION: v0.1.8
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download --repo reproducible-containers/diffoci "${DIFFOCI_VERSION}" --pattern "*linux-amd64" --output /usr/local/bin/diffoci
+          echo "$CHECKSUM  /usr/local/bin/diffoci" | sha256sum -c -
+          chmod +x /usr/local/bin/diffoci
+
+      # Check reproducibility
+      - name: Pull
+        run: docker pull "$IMAGE"
+      - name: Build
+        run: docker build --no-cache --file "$DOCKERFILE" --tag rebuild .
+      - name: Diff images
+        run: diffoci diff --semantic "docker://$IMAGE" docker://rebuild

--- a/.github/workflows/reusable-docker-image-test.yml
+++ b/.github/workflows/reusable-docker-image-test.yml
@@ -1,3 +1,8 @@
+# WARNING:
+# When using this reusable workflow, provide only trusted values to the input
+# `setup-cmd`. This input is embedded directly into a script because it is
+# meant to be executed as a command.
+
 name: Check
 on:
   workflow_call:
@@ -9,6 +14,10 @@ on:
       image:
         required: true
         type: string
+      setup-cmd:
+        required: false
+        type: string
+        default: ""
 
       # Target
       repository:
@@ -59,6 +68,9 @@ jobs:
           repository: ${{ inputs.repository }}
 
       # Environment setup
+      - name: Setup
+        if: ${{ inputs.setup-cmd != '' }}
+        run: ${{ inputs.setup-cmd }}
       - name: Install diffoci
         env:
           CHECKSUM: 01e6b50c1568c9d61c758ef6da81869f2c26c852698d73dca961b3617effe949

--- a/.github/workflows/reusable-node-test.yml
+++ b/.github/workflows/reusable-node-test.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           while IFS= read -r file; do
             echo "--- Diff of '$file' ---"
-            git diff "$file"
+            git diff --text "$file"
           done <"$FILES_LIST_FILE"
       - name: Check for new files
         run: |

--- a/.github/workflows/super-linter-super-linter.yml
+++ b/.github/workflows/super-linter-super-linter.yml
@@ -1,17 +1,17 @@
-name: mikefarah/yq
+name: super-linter/super-linter
 on:
   pull_request:
     paths:
       - .github/workflows/reusable-docker-image-test.yml
-      - .github/workflows/mikefarah-yq.yml
+      - .github/workflows/super-linter-super-linter.yml
   push:
     branches:
       - main
     paths:
       - .github/workflows/reusable-docker-image-test.yml
-      - .github/workflows/mikefarah-yq.yml
+      - .github/workflows/super-linter-super-linter.yml
   schedule:
-    - cron: "51 1 * * *"
+    - cron: "52 1 * * *"
   workflow_dispatch: ~
 
 permissions: read-all
@@ -21,10 +21,10 @@ jobs:
     uses: ./.github/workflows/reusable-docker-image-test.yml
     with:
       dockerfile: Dockerfile
-      image: mikefarah/yq:4-githubaction
-      repository: mikefarah/yq
+      image: ghcr.io/super-linter/super-linter:v8.5.0
+      repository: super-linter/super-linter
   version:
     if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: mikefarah/yq@v4.52.5
+      - uses: super-linter/super-linter@v8.5.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # Configuration file for asdf (https://asdf-vm.com/)
-actionlint 1.7.11
+actionlint 1.7.12
 shellcheck 0.11.0
 shfmt 3.13.0

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ with more information about the project and statuses.
 | [denoland/setup-deno] | [![][denoland/setup-deno-badge]][denoland/setup-deno-url] |
 | [oven-sh/setup-bun] | [![][oven-sh/setup-bun-badge]][oven-sh/setup-bun-url] |
 | [pnpm/action-setup] | [![][pnpm/action-setup-badge]][pnpm/action-setup-url] |
-<!-- INSERT ROW -->
+| [mikefarah/yq] | [![][mikefarah/yq-badge]][mikefarah/yq-url] |
 [pnpm/action-setup]: https://github.com/pnpm/action-setup
 [pnpm/action-setup-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/pnpm-action-setup.yml/badge.svg?event=schedule
 [pnpm/action-setup-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/pnpm-action-setup.yml
@@ -74,6 +74,10 @@ with more information about the project and statuses.
 [denoland/setup-deno]: https://github.com/denoland/setup-deno
 [denoland/setup-deno-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/denoland-setup-deno.yml/badge.svg?event=schedule
 [denoland/setup-deno-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/denoland-setup-deno.yml
+<!-- INSERT ROW -->
+[mikefarah/yq]: https://github.com/mikefarah/yq
+[mikefarah/yq-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/mikefarah-yq.yml/badge.svg?event=schedule
+[mikefarah/yq-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/mikefarah-yq.yml
 [norio-nomura/action-swiftlint]: https://github.com/norio-nomura/action-swiftlint
 [norio-nomura/action-swiftlint-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/norio-nomura-action-swiftlint.yml/badge.svg?event=schedule
 [norio-nomura/action-swiftlint-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/norio-nomura-action-swiftlint.yml

--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ with more information about the project and statuses.
 | [norio-nomura/action-swiftlint] | [![][norio-nomura/action-swiftlint-badge]][norio-nomura/action-swiftlint-url] |
 | [denoland/setup-deno] | [![][denoland/setup-deno-badge]][denoland/setup-deno-url] |
 | [oven-sh/setup-bun] | [![][oven-sh/setup-bun-badge]][oven-sh/setup-bun-url] |
+| [pnpm/action-setup] | [![][pnpm/action-setup-badge]][pnpm/action-setup-url] |
 <!-- INSERT ROW -->
+[pnpm/action-setup]: https://github.com/pnpm/action-setup
+[pnpm/action-setup-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/pnpm-action-setup.yml/badge.svg?event=schedule
+[pnpm/action-setup-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/pnpm-action-setup.yml
 [oven-sh/setup-bun]: https://github.com/oven-sh/setup-bun
 [oven-sh/setup-bun-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/oven-sh-setup-bun.yml/badge.svg?event=schedule
 [oven-sh/setup-bun-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/oven-sh-setup-bun.yml
@@ -331,6 +335,7 @@ project.
 | `JS-DevTools/npm-publish` | v4.0.0...v4.1.2 | [untracked files](https://github.com/JS-DevTools/npm-publish/pull/258) |
 | `stepci/stepci` | v1.0.5...v2.8.2 | [Node compile/npm cache](https://github.com/stepci/stepci/issues/260) |
 | `SonarSource/sonarqube-scan-action` | v7.1.0 | [outdated build](https://community.sonarsource.com/t/the-sonarsource-sonarqube-scan-action-7-1-0-build-output-is-not-reproducible/180749) |
+| `pnpm/action-setup` | v4.0.0...v5.0.0 | [outdated build](https://github.com/pnpm/action-setup/issues/34) |
 
 ## Related Work
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ with more information about the project and statuses.
 | [pnpm/action-setup] | [![][pnpm/action-setup-badge]][pnpm/action-setup-url] |
 | [mikefarah/yq] | [![][mikefarah/yq-badge]][mikefarah/yq-url] |
 | [super-linter/super-linter] | [![][super-linter/super-linter-badge]][super-linter/super-linter-url] |
+| [google/osv-scanner-action] | [![][google/osv-scanner-action-badge]][google/osv-scanner-action-url] |
+<!-- INSERT ROW -->
+[google/osv-scanner-action]: https://github.com/google/osv-scanner-action
+[google/osv-scanner-action-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/google-osv-scanner-action.yml/badge.svg?event=schedule
+[google/osv-scanner-action-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/google-osv-scanner-action.yml
 [super-linter/super-linter]: https://github.com/super-linter/super-linter
 [super-linter/super-linter-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/super-linter-super-linter.yml/badge.svg?event=schedule
 [super-linter/super-linter-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/super-linter-super-linter.yml

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ with more information about the project and statuses.
 | [oven-sh/setup-bun] | [![][oven-sh/setup-bun-badge]][oven-sh/setup-bun-url] |
 | [pnpm/action-setup] | [![][pnpm/action-setup-badge]][pnpm/action-setup-url] |
 | [mikefarah/yq] | [![][mikefarah/yq-badge]][mikefarah/yq-url] |
+| [super-linter/super-linter] | [![][super-linter/super-linter-badge]][super-linter/super-linter-url] |
+[super-linter/super-linter]: https://github.com/super-linter/super-linter
+[super-linter/super-linter-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/super-linter-super-linter.yml/badge.svg?event=schedule
+[super-linter/super-linter-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/super-linter-super-linter.yml
 [pnpm/action-setup]: https://github.com/pnpm/action-setup
 [pnpm/action-setup-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/pnpm-action-setup.yml/badge.svg?event=schedule
 [pnpm/action-setup-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/pnpm-action-setup.yml
@@ -74,7 +78,6 @@ with more information about the project and statuses.
 [denoland/setup-deno]: https://github.com/denoland/setup-deno
 [denoland/setup-deno-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/denoland-setup-deno.yml/badge.svg?event=schedule
 [denoland/setup-deno-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/denoland-setup-deno.yml
-<!-- INSERT ROW -->
 [mikefarah/yq]: https://github.com/mikefarah/yq
 [mikefarah/yq-badge]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/mikefarah-yq.yml/badge.svg?event=schedule
 [mikefarah/yq-url]: https://github.com/ericcornelissen/reproducing-actions/actions/workflows/mikefarah-yq.yml

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ project.
 | `stepci/stepci` | v1.0.5...v2.8.2 | [Node compile/npm cache](https://github.com/stepci/stepci/issues/260) |
 | `SonarSource/sonarqube-scan-action` | v7.1.0 | [outdated build](https://community.sonarsource.com/t/the-sonarsource-sonarqube-scan-action-7-1-0-build-output-is-not-reproducible/180749) |
 | `pnpm/action-setup` | v4.0.0...v5.0.0 | [outdated build](https://github.com/pnpm/action-setup/issues/34) |
+| `extractions/setup-crate` | v2.0.0 | [absolute path](https://github.com/extractions/setup-crate/issues/11) |
 
 ## Related Work
 

--- a/README.md
+++ b/README.md
@@ -305,13 +305,8 @@ script and Docker-based Actions. Adding a monitor is a manual effort so not all
 available Actions are monitored. If you want to add a new monitor, open a
 [new issue] or follow the instructions from the [Contributing Guidelines].
 
-Any non-JavaScript/Dockerilfe Action or any JavaScript-based Action without a
-build step is currently considered out of scope. If you have a need for
-monitoring of such Actions please check out and comment on [issue #1].
-
 [contributing guidelines]: ./CONTRIBUTING.md
 [new issue]: https://github.com/ericcornelissen/reproducing-actions/issues/new
-[issue #1]: https://github.com/ericcornelissen/reproducing-actions/issues/1
 
 ### Reproducibility Definition
 

--- a/new.sh
+++ b/new.sh
@@ -2,17 +2,38 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
 ## Arguments
-kind="$1"
-action="$2"
-version="$3"
+action="$1"
+version="$2"
+kind="$3"
 
 ## Usage
-if [[ -z ${kind} || -z ${action} || -z ${version} || (${kind} != 'node' && ${kind} != 'docker') ]]; then
-	echo 'USAGE:   ./new.sh <kind> <action> <version>'
+if [[ -z ${action} || -z ${version} || (${kind} != '' && ${kind} != 'node' && ${kind} != 'docker') ]]; then
+	echo 'USAGE:   ./new.sh <action> <version> [kind]'
 	echo 'EXAMPLE: ./new.sh node actions/checkout v6.0.1'
 	echo ''
-	echo 'where <kind> must be one of: "node", "docker"'
+	echo 'where <kind> can be one of: "node", "docker"'
 	exit 0
+fi
+
+if [[ -z ${kind} ]]; then
+	if ! manifest=$(curl -sf "https://raw.githubusercontent.com/${action}/refs/tags/${version}/action.yml"); then
+		echo "${action}@${version} not found"
+		exit 1
+	fi
+
+	using=$(echo "$manifest" | grep -oP "using:\s*['\"]?\K[^'\"]+")
+	case "${using}" in
+	node*)
+		kind='node'
+		;;
+	docker)
+		kind='docker'
+		;;
+	composite)
+		echo 'Composite actions are not monitored'
+		exit 1
+		;;
+	esac
 fi
 
 ## Derived values
@@ -28,10 +49,10 @@ fi
 
 ## Templates
 case "${kind}" in
-'node')
+node)
 	workflow=$(cat templates/workflow-node.yml)
 	;;
-'docker')
+docker)
 	workflow=$(cat templates/workflow-docker.yml)
 	;;
 esac


### PR DESCRIPTION
Trying out https://github.com/ericcornelissen/reproducing-actions/pull/232#issuecomment-4170485730
Relates to #224

## Summary

- Adds a monitor for `google/osv-scanner-action` using the `reusable-docker-image-test.yml` workflow
- Sets `repository: google/osv-scanner` (not `google/osv-scanner-action`) because the Dockerfile used to build the action image lives in the `google/osv-scanner` repo

## Why `goreleaser-action.dockerfile`?

The image `ghcr.io/google/osv-scanner-action` is built from `goreleaser-action.dockerfile` in `google/osv-scanner`. This is explicitly configured in [`.goreleaser.yml`](https://github.com/google/osv-scanner/blob/main/.goreleaser.yml):

```yaml
# Github Action
- image_templates:
    - "ghcr.io/google/osv-scanner-action:{{ .Tag }}"
  dockerfile: goreleaser-action.dockerfile
```

## Why `repository: google/osv-scanner`?

The `Dockerfile` (`goreleaser-action.dockerfile`) that builds the action image lives in [`google/osv-scanner`](https://github.com/google/osv-scanner), not in `google/osv-scanner-action`. The reusable workflow checks out the `repository` input to build from source, so it must point to where the Dockerfile actually is.

## Changes

- Add `.github/workflows/google-osv-scanner-action.yml`
- Add `<!-- INSERT ROW -->` back and `google/osv-scanner-action` entry to `README.md`