### PR TITLE
Disable Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     schedule:
       interval: daily
       time: "04:00"
+    cooldown:
+      default-days: 0


### PR DESCRIPTION
due to  https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/